### PR TITLE
fix: overlapping in container

### DIFF
--- a/react-cra/src/index.css
+++ b/react-cra/src/index.css
@@ -31,7 +31,8 @@ body,
 
 .container {
     display: flex;
-
+    padding-top: 64px;
+    position: relative;
 }
 
 main {


### PR DESCRIPTION
The top of the side menu was not visible due to the container going under the header. Also sometimes it shows two vertical scroll bars...