### PR TITLE
Test: variable migration beta.3 — Button / Tooltip / Tag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@ag-grid-community/client-side-row-model": "^32.1.0",
         "@ag-grid-community/react": "^32.0.0",
         "@faker-js/faker": "^8.4.1",
-        "@scania/tegel-react": "1.51.0",
+        "@scania/tegel-react": "1.51.0-var-work-beta.3",
         "@scania/tegel-styles": "1.0.0",
         "@tanstack/react-table": "^8.19.2",
         "@testing-library/jest-dom": "^5.16.5",
@@ -3724,9 +3724,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3746,9 +3743,6 @@
       "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3770,9 +3764,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3792,9 +3783,6 @@
       "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3816,9 +3804,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3838,9 +3823,6 @@
       "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4178,9 +4160,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4194,9 +4173,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4209,9 +4185,6 @@
       "integrity": "sha512-ZTR2mxBHb4tK4wGf9b8SYg0Y6KQPjGpR4UWwTFdnmjB4qRtoATZ5dWn3KsDwGa5Z2ZBOE7K52L36J9LueKBdOQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -4227,9 +4200,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4244,9 +4214,6 @@
       "cpu": [
         "loong64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4259,9 +4226,6 @@
       "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
       "cpu": [
         "loong64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4276,9 +4240,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4291,9 +4252,6 @@
       "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4308,9 +4266,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4323,9 +4278,6 @@
       "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4340,9 +4292,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4355,9 +4304,6 @@
       "integrity": "sha512-iUVJc3c0o8l9Sa/qlDL2Z9UP92UZZW1+EmQ4xfjTc1akr0iUFZNfxrXJ/R1T90h/ILm9iXEY6+iPrmYB3pXKjw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -4372,9 +4318,6 @@
       "integrity": "sha512-PQUobbhLTQT5yz/SPg116VJBgz+XOtXt8D1ck+sfJJhuEsMj2jSej5yTdp8CvWBSceu+WW+ibVL6dm0ptG5fcA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4476,9 +4419,9 @@
       "license": "MIT"
     },
     "node_modules/@scania/tegel": {
-      "version": "1.51.0",
-      "resolved": "https://registry.npmjs.org/@scania/tegel/-/tegel-1.51.0.tgz",
-      "integrity": "sha512-wChnv7mnY0aLWxMcCKPmcp2x81z6zzv0wchQTXHjf2YBu9AQRmZD2va+ldD+etO/wXc5jrGtHkpudcn/T9YKxg==",
+      "version": "1.51.0-var-work-beta.3",
+      "resolved": "https://registry.npmjs.org/@scania/tegel/-/tegel-1.51.0-var-work-beta.3.tgz",
+      "integrity": "sha512-t+I5oRfSaDFV9Dm/Mv6RzBmu+IcB61v0bNdnmbQdXxNQRCP/y/LMflPP2X0RkK0aE8PpORnYYsKZE3bsrG4z8g==",
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "2.11.8",
@@ -4491,12 +4434,12 @@
       }
     },
     "node_modules/@scania/tegel-react": {
-      "version": "1.51.0",
-      "resolved": "https://registry.npmjs.org/@scania/tegel-react/-/tegel-react-1.51.0.tgz",
-      "integrity": "sha512-ycBTtKxZuiqdXbeNl4bxfOAP1fTTPunKlM3+jpQXtipCwCk6jlNSPqOWbwcB5ezmdq1Fctzr18nq3DEyNGSAxA==",
+      "version": "1.51.0-var-work-beta.3",
+      "resolved": "https://registry.npmjs.org/@scania/tegel-react/-/tegel-react-1.51.0-var-work-beta.3.tgz",
+      "integrity": "sha512-geUEA+a7yEwP0AcU7pZG7kOzm30D6KtSRLeL+RjzTBjzpZgvaLgziVCllzJRT2btnD1U6LiHNTpzs9iOYzclUQ==",
       "license": "MIT",
       "dependencies": {
-        "@scania/tegel": "^1.51.0",
+        "@scania/tegel": "1.51.0-var-work-beta.3",
         "@stencil/react-output-target": "1.3.0"
       }
     },
@@ -4543,9 +4486,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4558,9 +4498,6 @@
       "integrity": "sha512-LD2fytxZJZ6xzOKnMbIpgzFOuIKlxVOpiMAXawsAZ2mHBPEYOnLRK5TTEsID6z4eM23DuO88X0Tq1mErHMVq0A==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4575,9 +4512,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4590,9 +4524,6 @@
       "integrity": "sha512-cYRpV4650z2I3/s6+5/LONkjIz8MBeqrk+vPXV10ORBnshpn8S32bPqQ2Utv39jCiDcO2eJTuSlPXpnvmaIgRA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4653,8 +4584,9 @@
       "version": "25.6.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
       "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
-      "extraneous": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.19.0"
       }
@@ -4779,9 +4711,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4794,9 +4723,6 @@
       "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4811,9 +4737,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4826,9 +4749,6 @@
       "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4940,8 +4860,9 @@
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "extraneous": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -19655,8 +19576,9 @@
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "extraneous": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -20288,8 +20210,9 @@
       "version": "7.19.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
       "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
-      "extraneous": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@ag-grid-community/client-side-row-model": "^32.1.0",
     "@ag-grid-community/react": "^32.0.0",
     "@faker-js/faker": "^8.4.1",
-    "@scania/tegel-react": "1.51.0",
+    "@scania/tegel-react": "1.51.0-var-work-beta.3",
     "@scania/tegel-styles": "1.0.0",
     "@tanstack/react-table": "^8.19.2",
     "@testing-library/jest-dom": "^5.16.5",

--- a/src/components/BrandSwitcher/BrandSwitcher.tsx
+++ b/src/components/BrandSwitcher/BrandSwitcher.tsx
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react';
+import { TdsToggle } from '@scania/tegel-react';
+
+type Brand = 'scania' | 'traton';
+
+const BRAND_CLASSES: Brand[] = ['scania', 'traton'];
+
+const applyBrandClass = (brand: Brand) => {
+  BRAND_CLASSES.forEach((b) => document.body.classList.remove(b));
+  document.body.classList.add(brand);
+};
+
+const BrandSwitcher = () => {
+  const [brand, setBrand] = useState<Brand>('scania');
+
+  useEffect(() => {
+    applyBrandClass(brand);
+  }, [brand]);
+
+  const toggleBrand = (event: any) => {
+    setBrand(event.detail.checked ? 'traton' : 'scania');
+  };
+
+  return (
+    <div className="mode-switcher">
+      <TdsToggle size="sm" headline="Brand" checked={brand === 'traton'} onTdsToggle={toggleBrand}>
+        <div slot="label">{brand === 'traton' ? 'Traton' : 'Scania'}</div>
+      </TdsToggle>
+    </div>
+  );
+};
+
+export default BrandSwitcher;

--- a/src/pages/About/About.scss
+++ b/src/pages/About/About.scss
@@ -1,0 +1,63 @@
+.about-beta-test {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  width: 100%;
+
+  &__intro {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  &__brand-toggle {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    padding: 16px;
+    border: 1px solid var(--tds-grey-300, #e4e4e4);
+    border-radius: 4px;
+  }
+
+  &__section {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    padding: 24px;
+    border: 1px solid var(--tds-grey-300, #e4e4e4);
+    border-radius: 4px;
+  }
+
+  &__section-title {
+    margin: 0;
+  }
+
+  &__state {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  &__state-label {
+    font-weight: 600;
+    margin: 0;
+  }
+
+  &__state-body {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    align-items: center;
+  }
+
+  &__tooltip-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 48px;
+    padding: 16px 0;
+  }
+
+  &__tooltip-anchor {
+    position: relative;
+  }
+}

--- a/src/pages/About/About.tsx
+++ b/src/pages/About/About.tsx
@@ -1,10 +1,249 @@
+import { TdsButton, TdsIcon, TdsTag, TdsTooltip } from '@scania/tegel-react';
+import BrandSwitcher from '../../components/BrandSwitcher/BrandSwitcher';
+import './About.scss';
+
+const Section = ({ title, children }: { title: string; children: React.ReactNode }) => (
+  <section className="about-beta-test__section">
+    <h3 className="tds-headline-03 about-beta-test__section-title">{title}</h3>
+    {children}
+  </section>
+);
+
+const State = ({ label, children }: { label: string; children: React.ReactNode }) => (
+  <div className="about-beta-test__state">
+    <p className="tds-detail-02 about-beta-test__state-label">{label}</p>
+    <div className="about-beta-test__state-body">{children}</div>
+  </div>
+);
+
+const noop = () => {};
+
 const About = () => {
   return (
-    <article>
-      <h3>About this page</h3>
-      <p>
-        This page is a testing ground and demo for using @scania/tegel-react in a React application.
-      </p>
+    <article className="about-beta-test">
+      <header className="about-beta-test__intro">
+        <h2 className="tds-headline-02">Variable migration test — 1.51.0-var-work-beta.3</h2>
+        <p className="tds-body-01">
+          Testing ground for the variable migration covering{' '}
+          <strong>Button, Tooltip and Tag</strong>. Toggle the brand to swap the{' '}
+          <code>.scania</code> / <code>.traton</code> class on the <code>body</code> element and
+          verify token output is correct across both brands.
+        </p>
+      </header>
+
+      <div className="about-beta-test__brand-toggle">
+        <BrandSwitcher />
+        <p className="tds-detail-05">
+          Adds/removes <code>.scania</code> / <code>.traton</code> on <code>body</code>.
+        </p>
+      </div>
+
+      {/* -------------------------------- Button -------------------------------- */}
+      <Section title="Button">
+        <State label="Variants — size lg">
+          <TdsButton onClick={noop} variant="primary" size="lg" text="Primary lg" />
+          <TdsButton onClick={noop} variant="secondary" size="lg" text="Secondary lg" />
+          <TdsButton onClick={noop} variant="ghost" size="lg" text="Ghost lg" />
+          <TdsButton onClick={noop} variant="danger" size="lg" text="Danger lg" />
+        </State>
+
+        <State label="Variants — size md">
+          <TdsButton onClick={noop} variant="primary" size="md" text="Primary md" />
+          <TdsButton onClick={noop} variant="secondary" size="md" text="Secondary md" />
+          <TdsButton onClick={noop} variant="ghost" size="md" text="Ghost md" />
+          <TdsButton onClick={noop} variant="danger" size="md" text="Danger md" />
+        </State>
+
+        <State label="Variants — size sm">
+          <TdsButton onClick={noop} variant="primary" size="sm" text="Primary sm" />
+          <TdsButton onClick={noop} variant="secondary" size="sm" text="Secondary sm" />
+          <TdsButton onClick={noop} variant="ghost" size="sm" text="Ghost sm" />
+          <TdsButton onClick={noop} variant="danger" size="sm" text="Danger sm" />
+        </State>
+
+        <State label="Variants — size xs">
+          <TdsButton onClick={noop} variant="primary" size="xs" text="Primary xs" />
+          <TdsButton onClick={noop} variant="secondary" size="xs" text="Secondary xs" />
+          <TdsButton onClick={noop} variant="ghost" size="xs" text="Ghost xs" />
+          <TdsButton onClick={noop} variant="danger" size="xs" text="Danger xs" />
+        </State>
+
+        <State label="Disabled state — all variants">
+          <TdsButton onClick={noop} variant="primary" size="md" text="Primary disabled" disabled />
+          <TdsButton
+            onClick={noop}
+            variant="secondary"
+            size="md"
+            text="Secondary disabled"
+            disabled
+          />
+          <TdsButton onClick={noop} variant="ghost" size="md" text="Ghost disabled" disabled />
+          <TdsButton onClick={noop} variant="danger" size="md" text="Danger disabled" disabled />
+        </State>
+
+        <State label="Fullbleed">
+          <div style={{ width: '100%' }}>
+            <TdsButton
+              onClick={noop}
+              variant="primary"
+              size="lg"
+              fullbleed
+              text="Primary fullbleed"
+            />
+          </div>
+        </State>
+
+        <State label="With icon — text + icon">
+          <TdsButton onClick={noop} variant="primary" size="md" text="With icon">
+            <TdsIcon slot="icon" size="16px" name="arrow_diagonal" />
+          </TdsButton>
+          <TdsButton onClick={noop} variant="secondary" size="md" text="With icon">
+            <TdsIcon slot="icon" size="16px" name="truck" />
+          </TdsButton>
+          <TdsButton onClick={noop} variant="ghost" size="md" text="With icon">
+            <TdsIcon slot="icon" size="16px" name="info" />
+          </TdsButton>
+          <TdsButton onClick={noop} variant="danger" size="md" text="With icon">
+            <TdsIcon slot="icon" size="16px" name="error" />
+          </TdsButton>
+        </State>
+
+        <State label="Icon-only buttons (no text)">
+          <TdsButton onClick={noop} variant="primary" size="md">
+            <TdsIcon slot="icon" size="16px" name="truck" />
+          </TdsButton>
+          <TdsButton onClick={noop} variant="secondary" size="md">
+            <TdsIcon slot="icon" size="16px" name="truck" />
+          </TdsButton>
+          <TdsButton onClick={noop} variant="ghost" size="md">
+            <TdsIcon slot="icon" size="16px" name="truck" />
+          </TdsButton>
+          <TdsButton onClick={noop} variant="danger" size="md">
+            <TdsIcon slot="icon" size="16px" name="error" />
+          </TdsButton>
+        </State>
+      </Section>
+
+      {/* -------------------------------- Tooltip ------------------------------- */}
+      <Section title="Tooltip">
+        <State label="Placement — top / right / bottom / left (hover the buttons)">
+          <div className="about-beta-test__tooltip-row">
+            <div className="about-beta-test__tooltip-anchor">
+              <TdsTooltip
+                placement="top"
+                selector="#tt-btn-top"
+                text="Tooltip on top"
+                mouseOverTooltip
+              />
+              <TdsButton id="tt-btn-top" size="sm" text="Top" />
+            </div>
+            <div className="about-beta-test__tooltip-anchor">
+              <TdsTooltip
+                placement="right"
+                selector="#tt-btn-right"
+                text="Tooltip on right"
+                mouseOverTooltip
+              />
+              <TdsButton id="tt-btn-right" size="sm" text="Right" />
+            </div>
+            <div className="about-beta-test__tooltip-anchor">
+              <TdsTooltip
+                placement="bottom"
+                selector="#tt-btn-bottom"
+                text="Tooltip on bottom"
+                mouseOverTooltip
+              />
+              <TdsButton id="tt-btn-bottom" size="sm" text="Bottom" />
+            </div>
+            <div className="about-beta-test__tooltip-anchor">
+              <TdsTooltip
+                placement="left"
+                selector="#tt-btn-left"
+                text="Tooltip on left"
+                mouseOverTooltip
+              />
+              <TdsButton id="tt-btn-left" size="sm" text="Left" />
+            </div>
+          </div>
+        </State>
+
+        <State label="Tooltip with rich slotted content (bold, italic)">
+          <div className="about-beta-test__tooltip-anchor">
+            <TdsTooltip placement="bottom" selector="#tt-btn-rich" mouseOverTooltip>
+              <p className="tds-detail-05" style={{ margin: 0 }}>
+                Rich content with <b>bold</b> and <i>italic</i> tags.
+              </p>
+            </TdsTooltip>
+            <TdsButton id="tt-btn-rich" size="sm" text="Hover for rich content" />
+          </div>
+        </State>
+
+        <State label="Tooltip with long text (wrapping edge case)">
+          <div className="about-beta-test__tooltip-anchor">
+            <TdsTooltip
+              placement="bottom"
+              selector="#tt-btn-long"
+              text="This is a much longer tooltip text meant to verify that wrapping, padding and line-height render correctly after the variable migration across both brands."
+              mouseOverTooltip
+            />
+            <TdsButton id="tt-btn-long" size="sm" text="Hover for long tooltip" />
+          </div>
+        </State>
+
+        <State label="Tooltip anchored to a disabled button">
+          <div className="about-beta-test__tooltip-anchor">
+            <TdsTooltip
+              placement="top"
+              selector="#tt-btn-disabled"
+              text="Anchored to a disabled button"
+              mouseOverTooltip
+            />
+            <TdsButton id="tt-btn-disabled" size="sm" text="Disabled anchor" disabled />
+          </div>
+        </State>
+      </Section>
+
+      {/* --------------------------------- Tag ---------------------------------- */}
+      <Section title="Tag">
+        <State label="Default size — all variants">
+          <TdsTag text="Tag Label" />
+          <TdsTag text="Information" variant="Information" />
+          <TdsTag text="Success" variant="Success" />
+          <TdsTag text="Warning" variant="Warning" />
+          <TdsTag text="Error" variant="Error" />
+          <TdsTag text="New" variant="New" />
+        </State>
+
+        <State label="Small size — all variants">
+          <TdsTag text="Tag Label" size="sm" />
+          <TdsTag text="Information" size="sm" variant="Information" />
+          <TdsTag text="Success" size="sm" variant="Success" />
+          <TdsTag text="Warning" size="sm" variant="Warning" />
+          <TdsTag text="Error" size="sm" variant="Error" />
+          <TdsTag text="New" size="sm" variant="New" />
+        </State>
+
+        <State label="Tags with prefix icon">
+          <TdsTag text="Info with icon" variant="Information">
+            <TdsIcon slot="prefix" name="info" size="16px" />
+          </TdsTag>
+          <TdsTag text="Success with icon" variant="Success">
+            <TdsIcon slot="prefix" name="tick" size="16px" />
+          </TdsTag>
+          <TdsTag text="Warning with icon" variant="Warning">
+            <TdsIcon slot="prefix" name="warning" size="16px" />
+          </TdsTag>
+          <TdsTag text="Error with icon" variant="Error">
+            <TdsIcon slot="prefix" name="error" size="16px" />
+          </TdsTag>
+        </State>
+
+        <State label="Tags with long labels (truncation edge case)">
+          <TdsTag text="A much longer tag label than usual" />
+          <TdsTag text="A much longer tag label than usual" variant="Information" />
+          <TdsTag text="A much longer tag label than usual" size="sm" variant="Success" />
+        </State>
+      </Section>
     </article>
   );
 };


### PR DESCRIPTION
## Summary
- Bumps `@scania/tegel-react` to **1.51.0-var-work-beta.3** so the variable migration for **Button, Tooltip** and **Tag** can be verified in the demo app.
- Rebuilds the About page as a dedicated test harness with multiple states per component: all button variants across `lg / md / sm / xs`, disabled state, fullbleed, text+icon and icon-only buttons; tooltips in every placement with default, rich-slotted, long-text and disabled-anchor cases; tags across all variants in both sizes plus prefix-icon and truncation cases.
- Adds a reusable `BrandSwitcher` component that toggles the `.scania` / `.traton` class on `document.body`, so the migrated tokens can be checked against both brands without a reload.

## What to test
- Visit **/about** and hover / tab through each section.
- Use the **Brand** toggle at the top of the page to flip between `.scania` and `.traton`; verify the color, spacing and typography variables that were migrated in beta.3 render correctly in both brands.
- Pay extra attention to the edge cases (disabled buttons, long tooltip text, tooltip on a disabled anchor, truncated tag labels).

## Test plan
- [ ] `npm start` and open `/about`
- [ ] Verify Button: all four variants in `lg / md / sm / xs`, disabled state, fullbleed, text+icon, icon-only
- [ ] Verify Tooltip: placements top / right / bottom / left, rich-slot content, long-text wrapping, disabled anchor
- [ ] Verify Tag: all variants in default and `sm` size, prefix-icon variants, long-label truncation
- [ ] Toggle brand between Scania and Traton and re-verify every state above

🤖 Generated with [Claude Code](https://claude.com/claude-code)