### PR TITLE
feat(about): test ground for var-migration beta (link, breadcrumbs, divider, footer)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "@ag-grid-community/client-side-row-model": "^32.1.0",
         "@ag-grid-community/react": "^32.0.0",
-        "@scania/tegel-react": "1.52.0",
+        "@scania/tegel": "1.52.0-var-work-beta.0",
+        "@scania/tegel-react": "1.52.0-var-work-beta.0",
         "@scania/tegel-styles": "1.0.0",
         "@tanstack/react-table": "^8.19.2",
         "@testing-library/jest-dom": "^5.16.5",
@@ -1862,9 +1863,9 @@
       "peer": true
     },
     "node_modules/@scania/tegel": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/@scania/tegel/-/tegel-1.52.0.tgz",
-      "integrity": "sha512-QCe8Kma07URhEyx3BkhBeBSduZFZgx/Hw4RBxiZuyB9Oju14eacQNYIdTHrB2v5psgZdEIqhZWBDWe9bZImorw==",
+      "version": "1.52.0-var-work-beta.0",
+      "resolved": "https://registry.npmjs.org/@scania/tegel/-/tegel-1.52.0-var-work-beta.0.tgz",
+      "integrity": "sha512-rbMvQ51fB4uoy+2MZbFDL5lCilpAn3xZpUHZg1sAg+pGzOHylEkGMXjZUaBU+Blpv0RPMdVIgfXm2a1Mi5Sh6Q==",
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "2.11.8",
@@ -1877,12 +1878,12 @@
       }
     },
     "node_modules/@scania/tegel-react": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/@scania/tegel-react/-/tegel-react-1.52.0.tgz",
-      "integrity": "sha512-2wdTbA76KLeJhQzO6BL04KFlE+hqjUG+TOHFc1ezBCA/XgZaD/vKB8sIMbZ7wjutlWjMVR4/Yj6Mcxyw8TfOHA==",
+      "version": "1.52.0-var-work-beta.0",
+      "resolved": "https://registry.npmjs.org/@scania/tegel-react/-/tegel-react-1.52.0-var-work-beta.0.tgz",
+      "integrity": "sha512-PuWKNsce+VSFygWDPLITaWpDRQP7CDH6hBmOh+p2QjHPYaw9oUgtNMLC47d9uWPkhlJDtPNGBRQZ/jP8YOa/lw==",
       "license": "MIT",
       "dependencies": {
-        "@scania/tegel": "^1.52.0",
+        "@scania/tegel": "1.52.0-var-work-beta.0",
         "@stencil/react-output-target": "1.3.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   "dependencies": {
     "@ag-grid-community/client-side-row-model": "^32.1.0",
     "@ag-grid-community/react": "^32.0.0",
-    "@scania/tegel-react": "1.52.0",
+    "@scania/tegel": "1.52.0-var-work-beta.0",
+    "@scania/tegel-react": "1.52.0-var-work-beta.0",
     "@scania/tegel-styles": "1.0.0",
     "@tanstack/react-table": "^8.19.2",
     "@testing-library/jest-dom": "^5.16.5",

--- a/src/pages/About/About.css
+++ b/src/pages/About/About.css
@@ -1,0 +1,125 @@
+.about-page {
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+  padding-bottom: 48px;
+}
+
+.about-header {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.brand-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 8px;
+  padding: 8px 12px;
+  border: 1px solid var(--tds-grey-300, #dadee4);
+  border-radius: 4px;
+}
+
+.brand-toggle__legend {
+  padding: 0 4px;
+  opacity: 0.6;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+}
+
+.brand-toggle__btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 14px;
+  border: 1px solid var(--tds-grey-400, #b0b7c4);
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+  border-radius: 4px;
+}
+
+.brand-toggle__btn input {
+  margin: 0;
+}
+
+.brand-toggle__btn--active {
+  background: var(--tds-blue-500, #2058a8);
+  color: #fff;
+  border-color: var(--tds-blue-500, #2058a8);
+}
+
+.brand-toggle__hint {
+  margin-left: 8px;
+  opacity: 0.7;
+}
+
+.about-section {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 16px 0;
+  border-top: 1px solid var(--tds-grey-300, #dadee4);
+}
+
+.about-section__body {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.about-case {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.about-case__label {
+  opacity: 0.7;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+}
+
+.about-case__demo {
+  padding: 12px 0;
+}
+
+.divider-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  width: 100%;
+  max-width: 480px;
+}
+
+.divider-grid__row {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.divider-grid__label {
+  opacity: 0.6;
+}
+
+.divider-vertical {
+  display: flex;
+  align-items: stretch;
+  gap: 16px;
+  height: 48px;
+}
+
+.divider-vertical__cell {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.divider-inline {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  height: 24px;
+}

--- a/src/pages/About/About.tsx
+++ b/src/pages/About/About.tsx
@@ -1,12 +1,452 @@
+/* eslint-disable jsx-a11y/anchor-is-valid */
+/** biome-ignore-all lint/a11y/useValidAnchor: Dummy links for visual testing */
+import { useEffect, useState } from "react";
+import {
+	TdsBreadcrumb,
+	TdsBreadcrumbs,
+	TdsDivider,
+	TdsFooter,
+	TdsFooterGroup,
+	TdsFooterItem,
+	TdsIcon,
+	TdsLink,
+} from "@scania/tegel-react";
+import "./About.css";
+
+type Brand = "scania" | "traton";
+
+const DIVIDER_VARIANTS = [
+	"discrete",
+	"subtle",
+	"soft",
+	"defined",
+	"dark-blue",
+] as const;
+
+const useBrand = (): [Brand, (next: Brand) => void] => {
+	const [brand, setBrand] = useState<Brand>(() => {
+		if (typeof document === "undefined") return "scania";
+		if (document.body.classList.contains("traton")) return "traton";
+		return "scania";
+	});
+
+	useEffect(() => {
+		const body = document.body;
+		body.classList.remove("scania", "traton");
+		body.classList.add(brand);
+	}, [brand]);
+
+	return [brand, setBrand];
+};
+
+const Section = ({
+	title,
+	children,
+}: {
+	title: string;
+	children: React.ReactNode;
+}) => (
+	<section className="about-section">
+		<h3 className="tds-headline-03">{title}</h3>
+		<div className="about-section__body">{children}</div>
+	</section>
+);
+
+const Case = ({
+	label,
+	children,
+}: {
+	label: string;
+	children: React.ReactNode;
+}) => (
+	<div className="about-case">
+		<div className="tds-detail-05 about-case__label">{label}</div>
+		<div className="about-case__demo">{children}</div>
+	</div>
+);
+
 const About = () => {
-  return (
-    <article>
-      <h3>About this page</h3>
-      <p>
-        This page is a testing ground and demo for using @scania/tegel-react in a React application.
-      </p>
-    </article>
-  );
+	const [brand, setBrand] = useBrand();
+
+	return (
+		<article className="about-page">
+			<header className="about-header">
+				<h2 className="tds-headline-02">
+					Variable migration beta — 1.52.0-var-work-beta.0
+				</h2>
+				<p className="tds-body-01">
+					Visual test ground for the components affected by the CSS variable
+					migration: <strong>Link</strong>, <strong>Breadcrumbs</strong>,{" "}
+					<strong>Divider</strong> and <strong>Footer</strong>. Switch brand to
+					verify that tokens resolve correctly for both Scania and Traton.
+				</p>
+				<fieldset className="brand-toggle">
+					<legend className="brand-toggle__legend tds-detail-05">Brand</legend>
+					<label
+						className={`brand-toggle__btn${brand === "scania" ? " brand-toggle__btn--active" : ""}`}
+					>
+						<input
+							type="radio"
+							name="brand"
+							value="scania"
+							checked={brand === "scania"}
+							onChange={() => setBrand("scania")}
+						/>
+						Scania
+					</label>
+					<label
+						className={`brand-toggle__btn${brand === "traton" ? " brand-toggle__btn--active" : ""}`}
+					>
+						<input
+							type="radio"
+							name="brand"
+							value="traton"
+							checked={brand === "traton"}
+							onChange={() => setBrand("traton")}
+						/>
+						Traton
+					</label>
+					<span className="brand-toggle__hint tds-detail-06">
+						body classname: <code>.{brand}</code>
+					</span>
+				</fieldset>
+			</header>
+
+			<Section title="Link">
+				<Case label="Default (inline, underlined)">
+					<p className="tds-body-01">
+						Read more about{" "}
+						<TdsLink>
+							<a href="#">the design system</a>
+						</TdsLink>{" "}
+						in the documentation.
+					</p>
+				</Case>
+				<Case label="Inline without underline">
+					<p className="tds-body-01">
+						Read more about{" "}
+						<TdsLink underline={false}>
+							<a href="#">the design system</a>
+						</TdsLink>{" "}
+						in the documentation.
+					</p>
+				</Case>
+				<Case label="Standalone (default)">
+					<TdsLink standalone>
+						<a href="#">Standalone link</a>
+					</TdsLink>
+				</Case>
+				<Case label="Standalone, no underline">
+					<TdsLink standalone underline={false}>
+						<a href="#">Standalone link</a>
+					</TdsLink>
+				</Case>
+				<Case label="Disabled (inline)">
+					<p className="tds-body-01">
+						This{" "}
+						<TdsLink disabled>
+							<a href="#">link is disabled</a>
+						</TdsLink>{" "}
+						and should not be interactive.
+					</p>
+				</Case>
+				<Case label="Disabled standalone">
+					<TdsLink standalone disabled>
+						<a href="#">Disabled standalone</a>
+					</TdsLink>
+				</Case>
+				<Case label="External target">
+					<TdsLink standalone>
+						<a target="_blank" rel="noreferrer" href="https://tegel.scania.com">
+							Open Tegel docs
+						</a>
+					</TdsLink>
+				</Case>
+				<Case label="With icon slot">
+					<TdsLink standalone>
+						<a href="#">
+							<TdsIcon name="truck" size="16px" slot="icon" />
+							Link with leading icon
+						</a>
+					</TdsLink>
+				</Case>
+				<Case label="Very long label (wrapping)">
+					<div style={{ maxWidth: 220 }}>
+						<TdsLink standalone>
+							<a href="#">
+								This is a very long link label that must wrap across multiple
+								lines to verify underline and focus handling
+							</a>
+						</TdsLink>
+					</div>
+				</Case>
+			</Section>
+
+			<Section title="Breadcrumbs">
+				<Case label="Single item">
+					<TdsBreadcrumbs>
+						<TdsBreadcrumb current>
+							<a href="#">Home</a>
+						</TdsBreadcrumb>
+					</TdsBreadcrumbs>
+				</Case>
+				<Case label="Two items">
+					<TdsBreadcrumbs>
+						<TdsBreadcrumb>
+							<a href="#">Home</a>
+						</TdsBreadcrumb>
+						<TdsBreadcrumb current>
+							<a href="#">About</a>
+						</TdsBreadcrumb>
+					</TdsBreadcrumbs>
+				</Case>
+				<Case label="Three items (typical)">
+					<TdsBreadcrumbs>
+						<TdsBreadcrumb>
+							<a href="#">Home</a>
+						</TdsBreadcrumb>
+						<TdsBreadcrumb>
+							<a href="#">Components</a>
+						</TdsBreadcrumb>
+						<TdsBreadcrumb current>
+							<a href="#">Breadcrumbs</a>
+						</TdsBreadcrumb>
+					</TdsBreadcrumbs>
+				</Case>
+				<Case label="Many items (overflow)">
+					<TdsBreadcrumbs tdsAriaLabel="Deep navigation">
+						<TdsBreadcrumb>
+							<a href="#">Home</a>
+						</TdsBreadcrumb>
+						<TdsBreadcrumb>
+							<a href="#">Products</a>
+						</TdsBreadcrumb>
+						<TdsBreadcrumb>
+							<a href="#">Heavy trucks</a>
+						</TdsBreadcrumb>
+						<TdsBreadcrumb>
+							<a href="#">R series</a>
+						</TdsBreadcrumb>
+						<TdsBreadcrumb>
+							<a href="#">Specifications</a>
+						</TdsBreadcrumb>
+						<TdsBreadcrumb current>
+							<a href="#">Powertrain</a>
+						</TdsBreadcrumb>
+					</TdsBreadcrumbs>
+				</Case>
+				<Case label="Long labels (clipping)">
+					<div style={{ maxWidth: 420 }}>
+						<TdsBreadcrumbs>
+							<TdsBreadcrumb>
+								<a href="#">Scania Digital Design System</a>
+							</TdsBreadcrumb>
+							<TdsBreadcrumb>
+								<a href="#">A very long intermediate breadcrumb item title</a>
+							</TdsBreadcrumb>
+							<TdsBreadcrumb current>
+								<a href="#">Current page with a particularly long title</a>
+							</TdsBreadcrumb>
+						</TdsBreadcrumbs>
+					</div>
+				</Case>
+			</Section>
+
+			<Section title="Divider">
+				<Case label="Horizontal — all variants">
+					<div className="divider-grid">
+						{DIVIDER_VARIANTS.map((variant) => (
+							<div className="divider-grid__row" key={variant}>
+								<span className="tds-detail-06 divider-grid__label">
+									{variant}
+								</span>
+								<TdsDivider variant={variant} />
+							</div>
+						))}
+					</div>
+				</Case>
+				<Case label="Vertical — all variants">
+					<div className="divider-vertical">
+						{DIVIDER_VARIANTS.map((variant) => (
+							<div className="divider-vertical__cell" key={variant}>
+								<span className="tds-detail-06">Left</span>
+								<TdsDivider orientation="vertical" variant={variant} />
+								<span className="tds-detail-06">{variant}</span>
+							</div>
+						))}
+					</div>
+				</Case>
+				<Case label="Horizontal between paragraphs (default)">
+					<p className="tds-body-01">Paragraph above the divider.</p>
+					<TdsDivider />
+					<p className="tds-body-01">Paragraph below the divider.</p>
+				</Case>
+				<Case label="Vertical inline with text">
+					<div className="divider-inline">
+						<span className="tds-body-01">Item A</span>
+						<TdsDivider orientation="vertical" />
+						<span className="tds-body-01">Item B</span>
+						<TdsDivider orientation="vertical" variant="defined" />
+						<span className="tds-body-01">Item C</span>
+					</div>
+				</Case>
+			</Section>
+
+			<Section title="Footer">
+				<Case label="Full footer (top + start + end)">
+					<TdsFooter>
+						<div slot="top">
+							<TdsFooterGroup title-text="Pages">
+								<TdsFooterItem>
+									<a href="#">Home</a>
+								</TdsFooterItem>
+								<TdsFooterItem>
+									<a href="#">Form</a>
+								</TdsFooterItem>
+							</TdsFooterGroup>
+							<TdsFooterGroup title-text="Legals">
+								<TdsFooterItem>
+									<a href="#">Terms &amp; Conditions</a>
+								</TdsFooterItem>
+								<TdsFooterItem>
+									<a href="#">Privacy policy</a>
+								</TdsFooterItem>
+							</TdsFooterGroup>
+							<TdsFooterGroup title-text="Design">
+								<TdsFooterItem>
+									<a href="#">Grid system</a>
+								</TdsFooterItem>
+								<TdsFooterItem>
+									<a href="#">Icons</a>
+								</TdsFooterItem>
+								<TdsFooterItem>
+									<a href="#">User personas</a>
+								</TdsFooterItem>
+							</TdsFooterGroup>
+							<TdsFooterGroup title-text="Support">
+								<TdsFooterItem>
+									<a href="#">Contact</a>
+								</TdsFooterItem>
+								<TdsFooterItem>
+									<a href="#">FAQ</a>
+								</TdsFooterItem>
+							</TdsFooterGroup>
+						</div>
+						<div slot="start">
+							<TdsFooterGroup>
+								<TdsFooterItem>
+									<a href="#">Imprint</a>
+								</TdsFooterItem>
+								<TdsFooterItem>
+									<a href="#">Cookies</a>
+								</TdsFooterItem>
+								<TdsFooterItem>
+									<a href="#">Sitemap</a>
+								</TdsFooterItem>
+							</TdsFooterGroup>
+						</div>
+						<div slot="end">
+							<TdsFooterGroup>
+								<TdsFooterItem>
+									<a href="#">
+										<TdsIcon name="truck" />
+									</a>
+								</TdsFooterItem>
+								<TdsFooterItem>
+									<a href="#">
+										<TdsIcon name="truck" />
+									</a>
+								</TdsFooterItem>
+								<TdsFooterItem>
+									<a href="#">
+										<TdsIcon name="truck" />
+									</a>
+								</TdsFooterItem>
+							</TdsFooterGroup>
+						</div>
+					</TdsFooter>
+				</Case>
+				<Case label="Minimal (start + end only, no top)">
+					<TdsFooter>
+						<div slot="start">
+							<TdsFooterGroup>
+								<TdsFooterItem>
+									<a href="#">Imprint</a>
+								</TdsFooterItem>
+								<TdsFooterItem>
+									<a href="#">Privacy</a>
+								</TdsFooterItem>
+								<TdsFooterItem>
+									<a href="#">Cookies</a>
+								</TdsFooterItem>
+							</TdsFooterGroup>
+						</div>
+						<div slot="end">
+							<TdsFooterGroup>
+								<TdsFooterItem>
+									<a href="#">
+										<TdsIcon name="truck" />
+									</a>
+								</TdsFooterItem>
+							</TdsFooterGroup>
+						</div>
+					</TdsFooter>
+				</Case>
+				<Case label="Start slot only">
+					<TdsFooter>
+						<div slot="start">
+							<TdsFooterGroup>
+								<TdsFooterItem>
+									<a href="#">
+										Copyright &copy; {new Date().getFullYear()} Scania
+									</a>
+								</TdsFooterItem>
+							</TdsFooterGroup>
+						</div>
+					</TdsFooter>
+				</Case>
+				<Case label="End slot only (icons)">
+					<TdsFooter>
+						<div slot="end">
+							<TdsFooterGroup>
+								<TdsFooterItem>
+									<a href="#">
+										<TdsIcon name="truck" />
+									</a>
+								</TdsFooterItem>
+								<TdsFooterItem>
+									<a href="#">
+										<TdsIcon name="truck" />
+									</a>
+								</TdsFooterItem>
+							</TdsFooterGroup>
+						</div>
+					</TdsFooter>
+				</Case>
+				<Case label="Top slot only (many groups)">
+					<TdsFooter>
+						<div slot="top">
+							{["Products", "Services", "About", "Support", "Legal"].map(
+								(group) => (
+									<TdsFooterGroup title-text={group} key={group}>
+										<TdsFooterItem>
+											<a href="#">Link one</a>
+										</TdsFooterItem>
+										<TdsFooterItem>
+											<a href="#">Link two</a>
+										</TdsFooterItem>
+										<TdsFooterItem>
+											<a href="#">Link three</a>
+										</TdsFooterItem>
+									</TdsFooterGroup>
+								),
+							)}
+						</div>
+					</TdsFooter>
+				</Case>
+			</Section>
+		</article>
+	);
 };
 
 export default About;


### PR DESCRIPTION
## Summary
- Bumps `@scania/tegel` and `@scania/tegel-react` to **1.52.0-var-work-beta.0** so the CSS-variable migration work can be exercised end-to-end in this demo.
- Rebuilds the `/about` page as a visual test ground for the four components the beta concerns — **Link**, **Breadcrumbs**, **Divider**, **Footer** — with every relevant prop/slot combination laid out side-by-side so regressions are easy to spot.
- Adds a **Scania / Traton brand toggle** that swaps the `.scania` / `.traton` classname on `<body>`, so token resolution can be verified against both brands without reloading.

### Edge cases covered
- **Link:** inline (default), inline without underline, standalone, standalone without underline, disabled (inline + standalone), external `target="_blank"`, leading-icon slot, long wrapping label.
- **Breadcrumbs:** 1 / 2 / 3 / many items, long labels in a constrained container, `tdsAriaLabel` set.
- **Divider:** all 5 variants (`discrete`, `subtle`, `soft`, `defined`, `dark-blue`) in both `horizontal` and `vertical` orientations, plus inline-with-text usage.
- **Footer:** full (top + start + end), minimal (start + end), start-only, end-only, top-only with many groups.

## Test plan
- [ ] `npm install` picks up the beta versions cleanly.
- [ ] Navigate to `/about` — every section renders without console errors.
- [ ] Toggle **Scania** ↔ **Traton** and confirm `<body>` gets the right classname and component colours/typography update accordingly.
- [ ] Verify each Link state (hover, focus, disabled, wrap) against the latest variable tokens for both brands.
- [ ] Verify Breadcrumbs separator, current-item styling, and overflow behaviour at narrow widths for both brands.
- [ ] Verify every Divider variant in both orientations for both brands.
- [ ] Verify each Footer slot configuration at desktop and mobile widths for both brands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)