### PR TITLE
chore: bump @scania/tegel and @scania/tegel-react to 1.53.0-field-var.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "@ag-grid-community/client-side-row-model": "^32.1.0",
         "@ag-grid-community/react": "^32.0.0",
-        "@scania/tegel-react": "1.53.0",
+        "@scania/tegel": "1.53.0-field-var.0",
+        "@scania/tegel-react": "1.53.0-field-var.0",
         "@scania/tegel-styles": "1.0.0",
         "@tanstack/react-table": "^8.19.2",
         "ag-grid-react": "32.0.0",
@@ -432,15 +433,6 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/runtime": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
-      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -558,9 +550,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -578,9 +567,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -598,9 +584,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -618,9 +601,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT OR Apache-2.0",
       "optional": true,
       "os": [
@@ -1692,9 +1672,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1708,9 +1685,6 @@
       "integrity": "sha512-GFWfAhVhWGd4r6UxmnKRTBwP1qmModHtd5gkraeW2G490BpFOZkFtem8yuX2NyafIP/mGpRJgTJ2PwohQkUY/Q==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1824,9 +1798,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1840,9 +1811,6 @@
       "integrity": "sha512-PQUobbhLTQT5yz/SPg116VJBgz+XOtXt8D1ck+sfJJhuEsMj2jSej5yTdp8CvWBSceu+WW+ibVL6dm0ptG5fcA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1936,9 +1904,9 @@
       "peer": true
     },
     "node_modules/@scania/tegel": {
-      "version": "1.53.0",
-      "resolved": "https://registry.npmjs.org/@scania/tegel/-/tegel-1.53.0.tgz",
-      "integrity": "sha512-eVdCDA5q2g8qeEHl1HWZTX5K8HQRdhN7w+UWUNzzdqYLvsRy5Lr/2eTl/wkAN8ryYArBlttr40Ui4nVYvLpEjQ==",
+      "version": "1.53.0-field-var.0",
+      "resolved": "https://registry.npmjs.org/@scania/tegel/-/tegel-1.53.0-field-var.0.tgz",
+      "integrity": "sha512-dHPjsW8peYJ1EQiPKsGRPbt4Z4JDXBS3R137nfZiwOasLHBedJAngxqYucRcvTCJzaPearRN7Xxea4wLebNowA==",
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "2.11.8",
@@ -1949,12 +1917,12 @@
       }
     },
     "node_modules/@scania/tegel-react": {
-      "version": "1.53.0",
-      "resolved": "https://registry.npmjs.org/@scania/tegel-react/-/tegel-react-1.53.0.tgz",
-      "integrity": "sha512-Y0wqCHGGVj0LXfoEXp61Nx8wzRv7ZBUm1tYYkz9CW1jPFhKWbYEoyhsR8HLeMIvYt9KohTo/pFI8nOTyWaUlYA==",
+      "version": "1.53.0-field-var.0",
+      "resolved": "https://registry.npmjs.org/@scania/tegel-react/-/tegel-react-1.53.0-field-var.0.tgz",
+      "integrity": "sha512-rwo/dKqik6jkmUWUvBz6Dq3kb08ws92deS7JkhNOh5Jef5BkSCOzW8FYXUANXBizJwLDZ2e2REX5MPrOn2Pq4w==",
       "license": "MIT",
       "dependencies": {
-        "@scania/tegel": "^1.53.0",
+        "@scania/tegel": "1.53.0-field-var.0",
         "@stencil/react-output-target": "1.3.0"
       }
     },
@@ -2001,9 +1969,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2016,9 +1981,6 @@
       "integrity": "sha512-LD2fytxZJZ6xzOKnMbIpgzFOuIKlxVOpiMAXawsAZ2mHBPEYOnLRK5TTEsID6z4eM23DuO88X0Tq1mErHMVq0A==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2033,9 +1995,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2048,9 +2007,6 @@
       "integrity": "sha512-cYRpV4650z2I3/s6+5/LONkjIz8MBeqrk+vPXV10ORBnshpn8S32bPqQ2Utv39jCiDcO2eJTuSlPXpnvmaIgRA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2275,7 +2231,7 @@
       "version": "20.19.39",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
       "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -2803,85 +2759,10 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "devOptional": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-bigints": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
-      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/has-property-descriptors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
-      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "license": "MIT",
-      "dependencies": {
-        "es-define-property": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-symbols": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "license": "MIT",
-      "dependencies": {
-        "has-symbols": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/hasown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/html-dom-parser": {
@@ -4049,22 +3930,6 @@
         "inline-style-parser": "0.2.7"
       }
     },
-    "node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
     "node_modules/sync-child-process": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/sync-child-process/-/sync-child-process-1.0.2.tgz",
@@ -4151,7 +4016,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   "dependencies": {
     "@ag-grid-community/client-side-row-model": "^32.1.0",
     "@ag-grid-community/react": "^32.0.0",
-    "@scania/tegel-react": "1.53.0",
+    "@scania/tegel": "1.53.0-field-var.0",
+    "@scania/tegel-react": "1.53.0-field-var.0",
     "@scania/tegel-styles": "1.0.0",
     "@tanstack/react-table": "^8.19.2",
     "ag-grid-react": "32.0.0",

--- a/src/pages/About/About.css
+++ b/src/pages/About/About.css
@@ -1,0 +1,112 @@
+.about-page {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  padding-bottom: 48px;
+}
+
+.about-header {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.brand-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 8px;
+  padding: 8px 12px;
+  border: 1px solid var(--tds-grey-300, #dadee4);
+  border-radius: 4px;
+}
+
+.brand-toggle__legend {
+  padding: 0 4px;
+  opacity: 0.6;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+}
+
+.brand-toggle__btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 14px;
+  border: 1px solid var(--tds-grey-400, #b0b7c4);
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+  border-radius: 4px;
+}
+
+.brand-toggle__btn input {
+  margin: 0;
+}
+
+.brand-toggle__btn--active {
+  background: var(--tds-blue-500, #2058a8);
+  color: #fff;
+  border-color: var(--tds-blue-500, #2058a8);
+}
+
+.brand-toggle__hint {
+  margin-left: 8px;
+  opacity: 0.7;
+}
+
+.section-divider {
+  margin-top: 24px;
+  padding-bottom: 8px;
+  border-bottom: 2px solid var(--tds-grey-300, #dadee4);
+}
+
+.component-section {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px;
+  border: 1px solid var(--tds-grey-300, #dadee4);
+  border-radius: 4px;
+}
+
+.component-section__hint {
+  margin: 0;
+  opacity: 0.75;
+}
+
+.variant-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 16px;
+  width: 100%;
+}
+
+.variant-grid__cell {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px;
+  border: 1px dashed var(--tds-grey-300, #dadee4);
+  border-radius: 4px;
+  min-height: 96px;
+}
+
+.variant-grid__cell--light {
+  background: var(--tds-grey-50, #f9fafb);
+}
+
+.variant-grid__cell--dark {
+  background: var(--tds-grey-958, #0d0f13);
+}
+
+.variant-grid__caption {
+  opacity: 0.7;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+}
+
+.variant-grid__cell--dark .variant-grid__caption {
+  color: var(--tds-grey-100, #e4e7ec);
+}

--- a/src/pages/About/About.tsx
+++ b/src/pages/About/About.tsx
@@ -1,10 +1,535 @@
+import { useEffect, useState } from "react";
+import { TdsIcon, TdsTextField, TdsTextarea } from "@scania/tegel-react";
+import "./About.css";
+
+type Brand = "scania" | "traton";
+
+const useBrand = (): [Brand, (next: Brand) => void] => {
+  const [brand, setBrand] = useState<Brand>(() => {
+    if (typeof document === "undefined") return "scania";
+    if (document.body.classList.contains("traton")) return "traton";
+    return "scania";
+  });
+
+  useEffect(() => {
+    const body = document.body;
+    body.classList.remove("scania", "traton");
+    body.classList.add(brand);
+    return () => {
+      body.classList.remove("scania", "traton");
+    };
+  }, [brand]);
+
+  return [brand, setBrand];
+};
+
+const SIZES = ["sm", "md", "lg"] as const;
+const LABEL_POSITIONS = ["no-label", "inside", "outside"] as const;
+const STATES = ["default", "success", "error"] as const;
+const MODE_VARIANTS = [null, "primary", "secondary"] as const;
+
 const About = () => {
+  const [brand, setBrand] = useBrand();
+
   return (
-    <article>
-      <h3>About this page</h3>
-      <p>
-        This page is a testing ground and demo for using @scania/tegel-react in a React application.
-      </p>
+    <article className="about-page">
+      <header className="about-header">
+        <h2 className="tds-headline-02">Text field variants (1.53.0-field-var.0)</h2>
+        <p className="tds-body-01">
+          Test ground for <code>tds-text-field</code> and <code>tds-textarea</code> variants in{" "}
+          <code>@scania/tegel 1.53.0-field-var.0</code>. Every section below isolates one prop axis
+          so you can visually verify each combination.
+        </p>
+        <fieldset className="brand-toggle">
+          <legend className="brand-toggle__legend tds-detail-05">Brand</legend>
+          <label
+            className={`brand-toggle__btn${brand === "scania" ? " brand-toggle__btn--active" : ""}`}
+          >
+            <input
+              type="radio"
+              name="brand"
+              value="scania"
+              checked={brand === "scania"}
+              onChange={() => setBrand("scania")}
+            />
+            Scania
+          </label>
+          <label
+            className={`brand-toggle__btn${brand === "traton" ? " brand-toggle__btn--active" : ""}`}
+          >
+            <input
+              type="radio"
+              name="brand"
+              value="traton"
+              checked={brand === "traton"}
+              onChange={() => setBrand("traton")}
+            />
+            Traton
+          </label>
+          <span className="brand-toggle__hint tds-detail-06">
+            body classname: <code>.{brand}</code>
+          </span>
+        </fieldset>
+      </header>
+
+      <h2 className="tds-headline-03 section-divider">tds-text-field</h2>
+
+      <section className="component-section">
+        <h3 className="tds-headline-04">Label positions</h3>
+        <p className="component-section__hint tds-detail-06">
+          <code>labelPosition</code>: no-label (default), inside, outside.
+        </p>
+        <div className="variant-grid">
+          {LABEL_POSITIONS.map((pos) => (
+            <div className="variant-grid__cell" key={`tf-label-${pos}`}>
+              <span className="variant-grid__caption tds-detail-06">{pos}</span>
+              <TdsTextField
+                labelPosition={pos}
+                label="Label text"
+                placeholder="Placeholder"
+                helper="Helper text"
+              />
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="component-section">
+        <h3 className="tds-headline-04">Sizes</h3>
+        <p className="component-section__hint tds-detail-06">
+          <code>size</code>: sm, md, lg (default).
+        </p>
+        <div className="variant-grid">
+          {SIZES.map((size) => (
+            <div className="variant-grid__cell" key={`tf-size-${size}`}>
+              <span className="variant-grid__caption tds-detail-06">{size}</span>
+              <TdsTextField
+                size={size}
+                labelPosition="outside"
+                label={`Size ${size}`}
+                placeholder="Placeholder"
+                helper="Helper text"
+              />
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="component-section">
+        <h3 className="tds-headline-04">States</h3>
+        <p className="component-section__hint tds-detail-06">
+          <code>state</code>: default, success, error.
+        </p>
+        <div className="variant-grid">
+          {STATES.map((state) => (
+            <div className="variant-grid__cell" key={`tf-state-${state}`}>
+              <span className="variant-grid__caption tds-detail-06">{state}</span>
+              <TdsTextField
+                state={state}
+                labelPosition="outside"
+                label={`State: ${state}`}
+                placeholder="Placeholder"
+                helper={
+                  state === "error"
+                    ? "Something is wrong"
+                    : state === "success"
+                      ? "Looks good!"
+                      : "Helper text"
+                }
+                value={state === "default" ? "" : "Some value"}
+              />
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="component-section">
+        <h3 className="tds-headline-04">Disabled and read-only</h3>
+        <p className="component-section__hint tds-detail-06">
+          <code>disabled</code>, <code>readOnly</code>, <code>readOnly + hideReadOnlyIcon</code>.
+        </p>
+        <div className="variant-grid">
+          <div className="variant-grid__cell">
+            <span className="variant-grid__caption tds-detail-06">disabled</span>
+            <TdsTextField
+              disabled
+              labelPosition="outside"
+              label="Disabled"
+              placeholder="Placeholder"
+              value="Disabled value"
+              helper="Helper text"
+            />
+          </div>
+          <div className="variant-grid__cell">
+            <span className="variant-grid__caption tds-detail-06">readOnly</span>
+            <TdsTextField
+              readOnly
+              labelPosition="outside"
+              label="Read only"
+              value="Read-only value"
+              helper="Helper text"
+            />
+          </div>
+          <div className="variant-grid__cell">
+            <span className="variant-grid__caption tds-detail-06">readOnly + hideReadOnlyIcon</span>
+            <TdsTextField
+              readOnly
+              hideReadOnlyIcon
+              labelPosition="outside"
+              label="Read only (no icon)"
+              value="Read-only value"
+              helper="Helper text"
+            />
+          </div>
+        </div>
+      </section>
+
+      <section className="component-section">
+        <h3 className="tds-headline-04">Mode variants</h3>
+        <p className="component-section__hint tds-detail-06">
+          <code>modeVariant</code>: null (default), primary, secondary. Rendered on alternating
+          backgrounds.
+        </p>
+        <div className="variant-grid">
+          {MODE_VARIANTS.map((mv, i) => (
+            <div
+              className={`variant-grid__cell variant-grid__cell--${i % 2 === 0 ? "light" : "dark"}`}
+              key={`tf-mode-${mv ?? "null"}`}
+            >
+              <span className="variant-grid__caption tds-detail-06">{mv ?? "null"}</span>
+              <TdsTextField
+                modeVariant={mv}
+                labelPosition="outside"
+                label={`Mode ${mv ?? "null"}`}
+                placeholder="Placeholder"
+                helper="Helper text"
+              />
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="component-section">
+        <h3 className="tds-headline-04">Prefix and suffix slots</h3>
+        <p className="component-section__hint tds-detail-06">
+          Icons in <code>slot="prefix"</code> and <code>slot="suffix"</code>.
+        </p>
+        <div className="variant-grid">
+          <div className="variant-grid__cell">
+            <span className="variant-grid__caption tds-detail-06">prefix only</span>
+            <TdsTextField labelPosition="outside" label="Prefix" placeholder="Search">
+              <TdsIcon slot="prefix" name="search" size="20px" />
+            </TdsTextField>
+          </div>
+          <div className="variant-grid__cell">
+            <span className="variant-grid__caption tds-detail-06">suffix only</span>
+            <TdsTextField
+              labelPosition="outside"
+              label="Suffix"
+              placeholder="Amount"
+              helper="With suffix icon"
+            >
+              <TdsIcon slot="suffix" name="info" size="20px" />
+            </TdsTextField>
+          </div>
+          <div className="variant-grid__cell">
+            <span className="variant-grid__caption tds-detail-06">prefix + suffix</span>
+            <TdsTextField
+              labelPosition="outside"
+              label="Both"
+              placeholder="Placeholder"
+              helper="Both slots filled"
+            >
+              <TdsIcon slot="prefix" name="search" size="20px" />
+              <TdsIcon slot="suffix" name="cross" size="20px" />
+            </TdsTextField>
+          </div>
+        </div>
+      </section>
+
+      <section className="component-section">
+        <h3 className="tds-headline-04">Input types</h3>
+        <p className="component-section__hint tds-detail-06">
+          <code>type</code>: text (default), password, number, email, tel.
+        </p>
+        <div className="variant-grid">
+          <div className="variant-grid__cell">
+            <span className="variant-grid__caption tds-detail-06">text</span>
+            <TdsTextField
+              type="text"
+              labelPosition="outside"
+              label="Text"
+              placeholder="Free text"
+            />
+          </div>
+          <div className="variant-grid__cell">
+            <span className="variant-grid__caption tds-detail-06">password</span>
+            <TdsTextField
+              type="password"
+              labelPosition="outside"
+              label="Password"
+              placeholder="••••••••"
+              value="secretvalue"
+            />
+          </div>
+          <div className="variant-grid__cell">
+            <span className="variant-grid__caption tds-detail-06">number</span>
+            <TdsTextField
+              type="number"
+              labelPosition="outside"
+              label="Number"
+              placeholder="0"
+              min={0}
+              max={100}
+              step={1}
+            />
+          </div>
+          <div className="variant-grid__cell">
+            <span className="variant-grid__caption tds-detail-06">number (hideNumberArrows)</span>
+            <TdsTextField
+              type="number"
+              hideNumberArrows
+              labelPosition="outside"
+              label="Number, no arrows"
+              placeholder="0"
+            />
+          </div>
+          <div className="variant-grid__cell">
+            <span className="variant-grid__caption tds-detail-06">email</span>
+            <TdsTextField
+              type="email"
+              labelPosition="outside"
+              label="Email"
+              placeholder="user@example.com"
+            />
+          </div>
+          <div className="variant-grid__cell">
+            <span className="variant-grid__caption tds-detail-06">tel</span>
+            <TdsTextField
+              type="tel"
+              labelPosition="outside"
+              label="Phone"
+              placeholder="+46 70 000 00 00"
+            />
+          </div>
+        </div>
+      </section>
+
+      <section className="component-section">
+        <h3 className="tds-headline-04">Required, maxLength, noMinWidth</h3>
+        <p className="component-section__hint tds-detail-06">Misc prop axes.</p>
+        <div className="variant-grid">
+          <div className="variant-grid__cell">
+            <span className="variant-grid__caption tds-detail-06">required</span>
+            <TdsTextField
+              required
+              labelPosition="outside"
+              label="Required"
+              placeholder="Required input"
+              helper="Field is required"
+            />
+          </div>
+          <div className="variant-grid__cell">
+            <span className="variant-grid__caption tds-detail-06">maxLength=20</span>
+            <TdsTextField
+              labelPosition="outside"
+              label="Max length"
+              placeholder="Up to 20 chars"
+              maxLength={20}
+              value="Twelve chars"
+            />
+          </div>
+          <div className="variant-grid__cell">
+            <span className="variant-grid__caption tds-detail-06">noMinWidth</span>
+            <TdsTextField
+              noMinWidth
+              labelPosition="outside"
+              label="No min width"
+              placeholder="Narrow"
+            />
+          </div>
+        </div>
+      </section>
+
+      <h2 className="tds-headline-03 section-divider">tds-textarea</h2>
+
+      <section className="component-section">
+        <h3 className="tds-headline-04">Label positions</h3>
+        <p className="component-section__hint tds-detail-06">
+          <code>labelPosition</code>: no-label (default), inside, outside.
+        </p>
+        <div className="variant-grid">
+          {LABEL_POSITIONS.map((pos) => (
+            <div className="variant-grid__cell" key={`ta-label-${pos}`}>
+              <span className="variant-grid__caption tds-detail-06">{pos}</span>
+              <TdsTextarea
+                labelPosition={pos}
+                label="Label text"
+                placeholder="Type something"
+                helper="Helper text"
+                rows={3}
+              />
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="component-section">
+        <h3 className="tds-headline-04">States</h3>
+        <p className="component-section__hint tds-detail-06">
+          <code>state</code>: default, success, error.
+        </p>
+        <div className="variant-grid">
+          {STATES.map((state) => (
+            <div className="variant-grid__cell" key={`ta-state-${state}`}>
+              <span className="variant-grid__caption tds-detail-06">{state}</span>
+              <TdsTextarea
+                state={state}
+                labelPosition="outside"
+                label={`State: ${state}`}
+                placeholder="Type something"
+                helper={
+                  state === "error"
+                    ? "Something is wrong"
+                    : state === "success"
+                      ? "Looks good!"
+                      : "Helper text"
+                }
+                value={state === "default" ? "" : "Some text in the textarea"}
+                rows={3}
+              />
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="component-section">
+        <h3 className="tds-headline-04">Disabled and read-only</h3>
+        <p className="component-section__hint tds-detail-06">
+          <code>disabled</code>, <code>readOnly</code>, <code>readOnly + hideReadOnlyIcon</code>.
+        </p>
+        <div className="variant-grid">
+          <div className="variant-grid__cell">
+            <span className="variant-grid__caption tds-detail-06">disabled</span>
+            <TdsTextarea
+              disabled
+              labelPosition="outside"
+              label="Disabled"
+              value="Disabled value"
+              helper="Helper text"
+              rows={3}
+            />
+          </div>
+          <div className="variant-grid__cell">
+            <span className="variant-grid__caption tds-detail-06">readOnly</span>
+            <TdsTextarea
+              readOnly
+              labelPosition="outside"
+              label="Read only"
+              value="Read-only value"
+              helper="Helper text"
+              rows={3}
+            />
+          </div>
+          <div className="variant-grid__cell">
+            <span className="variant-grid__caption tds-detail-06">readOnly + hideReadOnlyIcon</span>
+            <TdsTextarea
+              readOnly
+              hideReadOnlyIcon
+              labelPosition="outside"
+              label="Read only (no icon)"
+              value="Read-only value"
+              helper="Helper text"
+              rows={3}
+            />
+          </div>
+        </div>
+      </section>
+
+      <section className="component-section">
+        <h3 className="tds-headline-04">Mode variants</h3>
+        <p className="component-section__hint tds-detail-06">
+          <code>modeVariant</code>: null (default), primary, secondary. Rendered on alternating
+          backgrounds.
+        </p>
+        <div className="variant-grid">
+          {MODE_VARIANTS.map((mv, i) => (
+            <div
+              className={`variant-grid__cell variant-grid__cell--${i % 2 === 0 ? "light" : "dark"}`}
+              key={`ta-mode-${mv ?? "null"}`}
+            >
+              <span className="variant-grid__caption tds-detail-06">{mv ?? "null"}</span>
+              <TdsTextarea
+                modeVariant={mv}
+                labelPosition="outside"
+                label={`Mode ${mv ?? "null"}`}
+                placeholder="Type something"
+                helper="Helper text"
+                rows={3}
+              />
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="component-section">
+        <h3 className="tds-headline-04">Rows, cols and maxLength</h3>
+        <p className="component-section__hint tds-detail-06">
+          <code>rows</code>, <code>cols</code>, <code>maxLength</code>.
+        </p>
+        <div className="variant-grid">
+          <div className="variant-grid__cell">
+            <span className="variant-grid__caption tds-detail-06">rows=2</span>
+            <TdsTextarea
+              labelPosition="outside"
+              label="Short"
+              placeholder="2 rows"
+              rows={2}
+            />
+          </div>
+          <div className="variant-grid__cell">
+            <span className="variant-grid__caption tds-detail-06">rows=6</span>
+            <TdsTextarea
+              labelPosition="outside"
+              label="Tall"
+              placeholder="6 rows"
+              rows={6}
+            />
+          </div>
+          <div className="variant-grid__cell">
+            <span className="variant-grid__caption tds-detail-06">cols=20</span>
+            <TdsTextarea
+              labelPosition="outside"
+              label="Narrow cols"
+              placeholder="20 cols"
+              cols={20}
+              rows={3}
+            />
+          </div>
+          <div className="variant-grid__cell">
+            <span className="variant-grid__caption tds-detail-06">maxLength=50</span>
+            <TdsTextarea
+              labelPosition="outside"
+              label="Max length"
+              placeholder="Up to 50 chars"
+              maxLength={50}
+              value="A textarea with a maximum length set."
+              helper="Counter shown when maxLength is set"
+              rows={3}
+            />
+          </div>
+          <div className="variant-grid__cell">
+            <span className="variant-grid__caption tds-detail-06">noMinWidth</span>
+            <TdsTextarea
+              noMinWidth
+              labelPosition="outside"
+              label="No min width"
+              placeholder="Narrow"
+              rows={3}
+            />
+          </div>
+        </div>
+      </section>
     </article>
   );
 };


### PR DESCRIPTION
## Summary
- Bumps `@scania/tegel` and `@scania/tegel-react` to `1.53.0-field-var.0`.
- Rewrites the About page to be a test ground for `tds-text-field` and `tds-textarea` variants. Brand toggle (Scania/Traton) preserved.

## Test plan
- [ ] `npm install` succeeds
- [ ] `npm run dev` starts the demo
- [ ] About page renders all text-field and textarea variants
- [ ] Brand toggle (Scania/Traton) switches tokens on body class
- [ ] Variants render correctly in both light and dark mode

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>