### PR TITLE
chore: bump @scania/tegel-react to 1.55.0-var-batch-8-beta

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@ag-grid-community/client-side-row-model": "^32.1.0",
         "@ag-grid-community/react": "^32.0.0",
-        "@scania/tegel-react": "1.55.0",
+        "@scania/tegel-react": "1.55.0-var-batch-8-beta",
         "@scania/tegel-styles": "1.0.0",
         "@tanstack/react-table": "^8.19.2",
         "ag-grid-react": "32.0.0",
@@ -1903,9 +1903,9 @@
       "peer": true
     },
     "node_modules/@scania/tegel": {
-      "version": "1.55.0",
-      "resolved": "https://registry.npmjs.org/@scania/tegel/-/tegel-1.55.0.tgz",
-      "integrity": "sha512-N4/wUsFTKWOV7qlLeBd3PEpz93ueiTlIxUpnnb3J1KgGB8zf5WPEdrVi/5cQCPRv7CmJ6oIXvlMufEEeK3G0QQ==",
+      "version": "1.55.0-var-batch-8-beta",
+      "resolved": "https://registry.npmjs.org/@scania/tegel/-/tegel-1.55.0-var-batch-8-beta.tgz",
+      "integrity": "sha512-orlPngY7Eifs69nAdjoIOans3sOQAmDFAivWekE8VztnD8HBJ/QJgsh6xGHoKny47SJ61w2TAHUarvzRmeMqkg==",
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "2.11.8",
@@ -1916,12 +1916,12 @@
       }
     },
     "node_modules/@scania/tegel-react": {
-      "version": "1.55.0",
-      "resolved": "https://registry.npmjs.org/@scania/tegel-react/-/tegel-react-1.55.0.tgz",
-      "integrity": "sha512-RwEfmwAgaNvxHaSAf69eS5623WnxjAdvqZ33rhk5aCvDWSxKqfTe2ZhMCqSsWFW/Kg5+ZJOSF7tO41LFBjlz8Q==",
+      "version": "1.55.0-var-batch-8-beta",
+      "resolved": "https://registry.npmjs.org/@scania/tegel-react/-/tegel-react-1.55.0-var-batch-8-beta.tgz",
+      "integrity": "sha512-mkZgOGLEuqylpTQJ57zqn48bCQfHP8Z3im/z2DBtW3YJ2hbYtzAIXxCifSNytas7/40m0nNiTrxCQoLYQHsC2g==",
       "license": "MIT",
       "dependencies": {
-        "@scania/tegel": "^1.55.0",
+        "@scania/tegel": "1.55.0-var-batch-8-beta",
         "@stencil/react-output-target": "1.3.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@ag-grid-community/client-side-row-model": "^32.1.0",
     "@ag-grid-community/react": "^32.0.0",
-    "@scania/tegel-react": "1.55.0",
+    "@scania/tegel-react": "1.55.0-var-batch-8-beta",
     "@scania/tegel-styles": "1.0.0",
     "@tanstack/react-table": "^8.19.2",
     "ag-grid-react": "32.0.0",

--- a/src/pages/About/About.css
+++ b/src/pages/About/About.css
@@ -1,0 +1,61 @@
+.about {
+	display: flex;
+	flex-direction: column;
+	gap: 24px;
+	max-width: 720px;
+	padding: 16px 0;
+}
+
+.about__header {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+
+.about__header p {
+	margin: 0;
+	max-width: 60ch;
+}
+
+.component-section {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+	padding: 20px;
+	border: 1px solid var(--tds-grey-300, #dadee4);
+	border-radius: 4px;
+	background: var(--tds-grey-50, #fafafa);
+}
+
+.component-section h4 {
+	margin: 0;
+}
+
+.about__note {
+	margin: 0;
+	color: var(--tds-grey-600, #6b7280);
+}
+
+.about__brand {
+	background: var(--tds-blue-50, #f0f3fb);
+}
+
+.demo-column {
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+}
+
+.about__fieldset {
+	border: 0;
+	margin: 0;
+	padding: 0;
+}
+
+.about__fieldset legend {
+	padding: 0 0 8px;
+}
+
+.about code {
+	font-family: monospace;
+}

--- a/src/pages/About/About.tsx
+++ b/src/pages/About/About.tsx
@@ -1,12 +1,117 @@
+import { useState } from "react";
+import { TdsCheckbox, TdsRadioButton, TdsToggle } from "@scania/tegel-react";
+import "./About.css";
+
+type Brand = "scania" | "traton";
+
+const meals = [
+	{ value: "salmon", label: "Salmon" },
+	{ value: "veal", label: "Veal" },
+	{ value: "chicken", label: "Chicken" },
+];
+
 const About = () => {
-  return (
-    <article>
-      <h3>About this page</h3>
-      <p>
-        This page is a testing ground and demo for using @scania/tegel-react in a React application.
-      </p>
-    </article>
-  );
+	const [brand, setBrand] = useState<Brand>("scania");
+	const [meal, setMeal] = useState("salmon");
+
+	return (
+		<article className={`about ${brand}`}>
+			<header className="about__header">
+				<h3 className="tds-headline-02">Component test ground</h3>
+				<p className="tds-detail-02">
+					Testing <strong>@scania/tegel-react@1.55.0-var-batch-8-beta</strong>:
+					checkbox, radio button and toggle. Flip the brand to confirm each
+					component themes correctly in Scania and Traton.
+				</p>
+			</header>
+
+			<section className="component-section about__brand">
+				<h4 className="tds-headline-06">Brand</h4>
+				<p className="about__note tds-detail-05">
+					Toggles the <code>.scania</code> / <code>.traton</code> theme class on the
+					demo area below.
+				</p>
+				<TdsToggle
+					checked={brand === "traton"}
+					onTdsToggle={(e) => setBrand(e.detail.checked ? "traton" : "scania")}
+				>
+					<div slot="label">
+						Brand: {brand === "traton" ? "Traton" : "Scania"}
+					</div>
+				</TdsToggle>
+			</section>
+
+			<section className="component-section">
+				<h4 className="tds-headline-06">Checkbox</h4>
+				<p className="about__note tds-detail-05">
+					<code>tds-checkbox</code> in its core states.
+				</p>
+				<div className="demo-column">
+					<TdsCheckbox>
+						<div slot="label">Default</div>
+					</TdsCheckbox>
+					<TdsCheckbox checked>
+						<div slot="label">Checked</div>
+					</TdsCheckbox>
+					<TdsCheckbox indeterminate>
+						<div slot="label">Indeterminate</div>
+					</TdsCheckbox>
+					<TdsCheckbox disabled>
+						<div slot="label">Disabled</div>
+					</TdsCheckbox>
+					<TdsCheckbox disabled checked>
+						<div slot="label">Disabled & checked</div>
+					</TdsCheckbox>
+				</div>
+			</section>
+
+			<section className="component-section">
+				<h4 className="tds-headline-06">Radio button</h4>
+				<p className="about__note tds-detail-05">
+					<code>tds-radio-button</code> as a single-select group.
+				</p>
+				<fieldset className="demo-column about__fieldset">
+					<legend className="tds-detail-05">Choose a meal</legend>
+					{meals.map(({ value, label }) => (
+						<TdsRadioButton
+							key={value}
+							name="meal"
+							value={value}
+							radio-id={`meal-${value}`}
+							checked={meal === value}
+							onTdsChange={() => setMeal(value)}
+						>
+							<span slot="label">{label}</span>
+						</TdsRadioButton>
+					))}
+					<TdsRadioButton name="meal" value="soldout" radio-id="meal-soldout" disabled>
+						<span slot="label">Sold out (disabled)</span>
+					</TdsRadioButton>
+				</fieldset>
+			</section>
+
+			<section className="component-section">
+				<h4 className="tds-headline-06">Toggle</h4>
+				<p className="about__note tds-detail-05">
+					<code>tds-toggle</code> in both sizes and states.
+				</p>
+				<div className="demo-column">
+					<TdsToggle headline="Large">
+						<div slot="label">Off by default</div>
+					</TdsToggle>
+					<TdsToggle headline="Large" checked>
+						<div slot="label">On by default</div>
+					</TdsToggle>
+					<TdsToggle size="sm" headline="Small">
+						<div slot="label">Small size</div>
+					</TdsToggle>
+					<TdsToggle headline="Disabled" disabled>
+						<div slot="label">Disabled</div>
+					</TdsToggle>
+				</div>
+			</section>
+		</article>
+	);
 };
 
 export default About;


### PR DESCRIPTION
## Summary

- Bump `@scania/tegel-react` to `1.55.0-var-batch-8-beta`.
- Rework the About page into a component test ground for **checkbox, radio button and toggle**.
- Add a Scania/Traton **brand toggle** that themes the demo area so the components can be verified in both brands.

## Components covered

`tds-checkbox` (default / checked / indeterminate / disabled), `tds-radio-button` (single-select group + disabled), `tds-toggle` (large / small / checked / disabled).

## Test plan

- [ ] `npm install` runs clean
- [ ] dev server boots
- [ ] About page renders without console errors
- [ ] Brand toggle flips `.scania` / `.traton` and re-themes all three components
- [ ] Checkbox states render correctly
- [ ] Radio group is single-select; disabled option not selectable
- [ ] Toggle switches and disabled toggle is inert

🤖 Generated with [Claude Code](https://claude.com/claude-code)