### PR TITLE
chore: bump @scania/tegel-react to 1.55.0-var-batch-8-beta

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@ag-grid-community/client-side-row-model": "^32.1.0",
         "@ag-grid-community/react": "^32.0.0",
-        "@scania/tegel-react": "1.55.0",
+        "@scania/tegel-react": "1.55.0-var-batch-8-beta",
         "@scania/tegel-styles": "1.0.0",
         "@tanstack/react-table": "^8.19.2",
         "ag-grid-react": "32.0.0",
@@ -1903,9 +1903,9 @@
       "peer": true
     },
     "node_modules/@scania/tegel": {
-      "version": "1.55.0",
-      "resolved": "https://registry.npmjs.org/@scania/tegel/-/tegel-1.55.0.tgz",
-      "integrity": "sha512-N4/wUsFTKWOV7qlLeBd3PEpz93ueiTlIxUpnnb3J1KgGB8zf5WPEdrVi/5cQCPRv7CmJ6oIXvlMufEEeK3G0QQ==",
+      "version": "1.55.0-var-batch-8-beta",
+      "resolved": "https://registry.npmjs.org/@scania/tegel/-/tegel-1.55.0-var-batch-8-beta.tgz",
+      "integrity": "sha512-orlPngY7Eifs69nAdjoIOans3sOQAmDFAivWekE8VztnD8HBJ/QJgsh6xGHoKny47SJ61w2TAHUarvzRmeMqkg==",
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "2.11.8",
@@ -1916,12 +1916,12 @@
       }
     },
     "node_modules/@scania/tegel-react": {
-      "version": "1.55.0",
-      "resolved": "https://registry.npmjs.org/@scania/tegel-react/-/tegel-react-1.55.0.tgz",
-      "integrity": "sha512-RwEfmwAgaNvxHaSAf69eS5623WnxjAdvqZ33rhk5aCvDWSxKqfTe2ZhMCqSsWFW/Kg5+ZJOSF7tO41LFBjlz8Q==",
+      "version": "1.55.0-var-batch-8-beta",
+      "resolved": "https://registry.npmjs.org/@scania/tegel-react/-/tegel-react-1.55.0-var-batch-8-beta.tgz",
+      "integrity": "sha512-mkZgOGLEuqylpTQJ57zqn48bCQfHP8Z3im/z2DBtW3YJ2hbYtzAIXxCifSNytas7/40m0nNiTrxCQoLYQHsC2g==",
       "license": "MIT",
       "dependencies": {
-        "@scania/tegel": "^1.55.0",
+        "@scania/tegel": "1.55.0-var-batch-8-beta",
         "@stencil/react-output-target": "1.3.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@ag-grid-community/client-side-row-model": "^32.1.0",
     "@ag-grid-community/react": "^32.0.0",
-    "@scania/tegel-react": "1.55.0",
+    "@scania/tegel-react": "1.55.0-var-batch-8-beta",
     "@scania/tegel-styles": "1.0.0",
     "@tanstack/react-table": "^8.19.2",
     "ag-grid-react": "32.0.0",


### PR DESCRIPTION
## Summary

- Bump `@scania/tegel-react` to `1.55.0-var-batch-8-beta`. Version bump only.

## Test plan

- [ ] `npm install` runs clean
- [ ] dev server boots; app renders without console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)