### PR TITLE
chore: bump @scania/tegel-react to 1.58.0-memory-fix-beta.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@ag-grid-community/client-side-row-model": "^32.1.0",
         "@ag-grid-community/react": "^32.0.0",
-        "@scania/tegel-react": "1.58.0",
+        "@scania/tegel-react": "1.58.0-memory-fix-beta.0",
         "@scania/tegel-styles": "1.0.0",
         "@tanstack/react-table": "^8.19.2",
         "ag-grid-react": "32.0.0",
@@ -1903,9 +1903,9 @@
       "peer": true
     },
     "node_modules/@scania/tegel": {
-      "version": "1.58.0",
-      "resolved": "https://registry.npmjs.org/@scania/tegel/-/tegel-1.58.0.tgz",
-      "integrity": "sha512-bBH7bLIZew/bWZL/7JSZksta2ingEPaWJTkQTA2vR+gfAEIub2zXk03TjhAzNUWq8g6VofubBVbiKkmzObcuGQ==",
+      "version": "1.58.0-memory-fix-beta.0",
+      "resolved": "https://registry.npmjs.org/@scania/tegel/-/tegel-1.58.0-memory-fix-beta.0.tgz",
+      "integrity": "sha512-ZV9yTAjwdzyDZbiIYMa45EuC7cAv+PVKY2co/HorYnRZxLKe5xGEpU28jslcfN/jGZ/LkTn1/6ffreRKI6FSHg==",
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "2.11.8",
@@ -1916,12 +1916,12 @@
       }
     },
     "node_modules/@scania/tegel-react": {
-      "version": "1.58.0",
-      "resolved": "https://registry.npmjs.org/@scania/tegel-react/-/tegel-react-1.58.0.tgz",
-      "integrity": "sha512-a/S8S40oB9B1vbL6Wwyu/F1RXvFHWltRO1LfY3oE/7eP/aFWt73ol8flgWzfKSr5bCmaamHz9/UHT+ol5Cvg9A==",
+      "version": "1.58.0-memory-fix-beta.0",
+      "resolved": "https://registry.npmjs.org/@scania/tegel-react/-/tegel-react-1.58.0-memory-fix-beta.0.tgz",
+      "integrity": "sha512-MREQpFZ/hP+e8skoL3QEEH1Wq9eIRvb8pPUt2Y0Nt8Pu745OEaCM7AhifMlAbjCuD+350vdYBYVa9zdcx4j0Wg==",
       "license": "MIT",
       "dependencies": {
-        "@scania/tegel": "^1.58.0",
+        "@scania/tegel": "1.58.0-memory-fix-beta.0",
         "@stencil/react-output-target": "1.3.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@ag-grid-community/client-side-row-model": "^32.1.0",
     "@ag-grid-community/react": "^32.0.0",
-    "@scania/tegel-react": "1.58.0",
+    "@scania/tegel-react": "1.58.0-memory-fix-beta.0",
     "@scania/tegel-styles": "1.0.0",
     "@tanstack/react-table": "^8.19.2",
     "ag-grid-react": "32.0.0",


### PR DESCRIPTION
## Summary

- Bump `@scania/tegel-react` to `1.58.0-memory-fix-beta.0` (memory-fix beta).
- Dependency bump only — no source or About-page changes.
- Branched off `main` (no `develop` branch exists on this repo).
- Note: this repo has no `@scania/tegel` dependency, only `@scania/tegel-react`.

## Validation

- `tsc -b` passed locally.

## Test plan

- [ ] `npm install` runs clean
- [ ] dev server boots
- [ ] App renders without console errors