### PR TITLE
Feat(dropdown): bump tegel-react version to have new dropdown styles 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@ag-grid-community/client-side-row-model": "^32.1.0",
         "@ag-grid-community/react": "^32.0.0",
-        "@scania/tegel-react": "^1.62.0",
+        "@scania/tegel-react": "1.62.0-dropdown-vars-beta.1",
         "@scania/tegel-styles": "1.0.0",
         "@tanstack/react-table": "^8.19.2",
         "ag-grid-react": "^32.3.9",
@@ -1496,9 +1496,9 @@
       "peer": true
     },
     "node_modules/@scania/tegel": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/@scania/tegel/-/tegel-1.62.0.tgz",
-      "integrity": "sha512-X8UmOdNxIQJfKb17+6284ve3GljaWuj3/ypndlEubQQpdIad2G8sQSXxuDaaa7ObQIsd9HTStGyjc8PWWLrRcA==",
+      "version": "1.62.0-dropdown-vars-beta.1",
+      "resolved": "https://registry.npmjs.org/@scania/tegel/-/tegel-1.62.0-dropdown-vars-beta.1.tgz",
+      "integrity": "sha512-x6sFeZdOwP+TMxAbMpH+vTqHBh+FLxpzSSjng2wP5ZF4e5z7kksyig4rNzlV9GDSoClOFycCF4FMVDa/EcdjWA==",
       "license": "MIT",
       "dependencies": {
         "@popperjs/core": "2.11.8",
@@ -1509,12 +1509,12 @@
       }
     },
     "node_modules/@scania/tegel-react": {
-      "version": "1.62.0",
-      "resolved": "https://registry.npmjs.org/@scania/tegel-react/-/tegel-react-1.62.0.tgz",
-      "integrity": "sha512-A7n+L8EYPyKbaNy5ezvm0cjvqUaZ9boGfaO0VBe/tLnruqJWVHLwn6HjntKdStS1aKplrEJaiPqCnU0KxCEOvA==",
+      "version": "1.62.0-dropdown-vars-beta.1",
+      "resolved": "https://registry.npmjs.org/@scania/tegel-react/-/tegel-react-1.62.0-dropdown-vars-beta.1.tgz",
+      "integrity": "sha512-g2lwJQI2zkOF3aAeYCgm4j09pC+kwe3903uWNl4j+U6Suvd0yh9QfFUx9uLR6qjgIqMFdwyrI6eM3aTS++/ySQ==",
       "license": "MIT",
       "dependencies": {
-        "@scania/tegel": "^1.62.0",
+        "@scania/tegel": "1.62.0-dropdown-vars-beta.1",
         "@stencil/react-output-target": "1.3.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@ag-grid-community/client-side-row-model": "^32.1.0",
     "@ag-grid-community/react": "^32.0.0",
-    "@scania/tegel-react": "^1.62.0",
+    "@scania/tegel-react": "1.62.0-dropdown-vars-beta.1",
     "@scania/tegel-styles": "1.0.0",
     "@tanstack/react-table": "^8.19.2",
     "ag-grid-react": "^32.3.9",

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -1,33 +1,106 @@
-import { TdsDropdown, TdsDropdownOption } from '@scania/tegel-react';
+import { TdsDropdown, TdsDropdownOption } from "@scania/tegel-react";
 
 const Dropdown = () => {
-  return (
-    <>
-      <div className="tds-headline-02 tds-u-pb1">Dropdown</div>
-      <TdsDropdown
-        name="dropdown"
-        label="Label text"
-        label-position="outside"
-        placeholder="Placeholder"
-        helper="Helper text"
-        size="lg"
-        multiselect
-        filter
-        open-direction="auto"
-        normalizeText={true}
-      >
-        <TdsDropdownOption value="optión-1">Äptión 1</TdsDropdownOption>
-        <TdsDropdownOption disabled value="optîón-2">
-          Optîon 2
-        </TdsDropdownOption>
-        <TdsDropdownOption value="optiôn-3">Öptiôn 3</TdsDropdownOption>
-        <TdsDropdownOption value="åptiõn-4">Åptiõn 4</TdsDropdownOption>
-        <TdsDropdownOption value="optiöñ-5">Optiöñ 5</TdsDropdownOption>
-        <TdsDropdownOption value="optiôñ-6">Optiôñ 6</TdsDropdownOption>
-        <TdsDropdownOption value="optiõñ-7">Optiõñ 7</TdsDropdownOption>
-      </TdsDropdown>
-    </>
-  );
+	return (
+		<>
+			<div className="tds-headline-02 tds-u-pb1">Dropdown</div>
+			<div className="tds-headline-03 tds-u-pb1">Simple Dropdown (Large) with Label inside</div>
+
+			<TdsDropdown
+				name="dropdown"
+				label="Label text"
+				label-position="inside"
+				placeholder="Placeholder"
+				helper="Helper text"
+				size="lg"
+				open-direction="auto"
+				normalizeText={true}
+			>
+				<TdsDropdownOption value="option-1">Option 1</TdsDropdownOption>
+				<TdsDropdownOption disabled value="option-2">
+					Option 2
+				</TdsDropdownOption>
+				<TdsDropdownOption value="option-3">Option 3</TdsDropdownOption>
+				<TdsDropdownOption value="option-4">Option 4</TdsDropdownOption>
+				<TdsDropdownOption value="option-5">Option 5</TdsDropdownOption>
+				<TdsDropdownOption value="option-6">Option 6</TdsDropdownOption>
+				<TdsDropdownOption value="option-7">Option 7</TdsDropdownOption>
+			</TdsDropdown>
+
+			<div className="tds-headline-03 tds-u-pb1">Multiselect Dropdown (Large) with filter</div>
+
+			<TdsDropdown
+				name="multiselect-dropdown"
+				label="Label text"
+				label-position="outside"
+				placeholder="Placeholder"
+				helper="Helper text"
+				size="lg"
+				multiselect
+				filter
+				open-direction="auto"
+				normalizeText={true}
+			>
+				<TdsDropdownOption value="option-1">Option 1</TdsDropdownOption>
+				<TdsDropdownOption disabled value="option-2">
+					Option 2
+				</TdsDropdownOption>
+				<TdsDropdownOption value="option-3">Option 3</TdsDropdownOption>
+				<TdsDropdownOption value="option-4">Option 4</TdsDropdownOption>
+				<TdsDropdownOption value="option-5">Option 5</TdsDropdownOption>
+				<TdsDropdownOption value="option-6">Option 6</TdsDropdownOption>
+				<TdsDropdownOption value="option-7">Option 7</TdsDropdownOption>
+			</TdsDropdown>
+
+			<div className="tds-headline-03 tds-u-pb1">Dropdown (Medium) with Error State</div>
+
+			<TdsDropdown
+				name="error-dropdown"
+				label="Label text"
+				label-position="inside"
+				placeholder="Placeholder"
+				helper="Helper text error"
+				size="md"
+				error
+				open-direction="auto"
+				normalizeText={true}
+			>
+				<TdsDropdownOption value="option-1">Option 1</TdsDropdownOption>
+				<TdsDropdownOption disabled value="option-2">
+					Option 2
+				</TdsDropdownOption>
+				<TdsDropdownOption value="option-3">Option 3</TdsDropdownOption>
+				<TdsDropdownOption value="option-4">Option 4</TdsDropdownOption>
+				<TdsDropdownOption value="option-5">Option 5</TdsDropdownOption>
+				<TdsDropdownOption value="option-6">Option 6</TdsDropdownOption>
+				<TdsDropdownOption value="option-7">Option 7</TdsDropdownOption>
+			</TdsDropdown>
+
+			<div className="tds-headline-03 tds-u-pb1">Disabled Dropdown (Medium)</div>
+
+			<TdsDropdown
+				name="error-dropdown"
+				label="Label text"
+				label-position="outside"
+				placeholder="Placeholder"
+				helper="Helper text error"
+				size="md"
+				disabled
+				open-direction="auto"
+				normalizeText={true}
+			>
+				<TdsDropdownOption value="option-1">Option 1</TdsDropdownOption>
+				<TdsDropdownOption disabled value="option-2">
+					Option 2
+				</TdsDropdownOption>
+				<TdsDropdownOption value="option-3">Option 3</TdsDropdownOption>
+				<TdsDropdownOption value="option-4">Option 4</TdsDropdownOption>
+				<TdsDropdownOption value="option-5">Option 5</TdsDropdownOption>
+				<TdsDropdownOption value="option-6">Option 6</TdsDropdownOption>
+				<TdsDropdownOption value="option-7">Option 7</TdsDropdownOption>
+			</TdsDropdown>
+		</>
+	);
 };
 
 export default Dropdown;

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -79,7 +79,7 @@ const Dropdown = () => {
 			<div className="tds-headline-03 tds-u-pb1">Disabled Dropdown (Medium)</div>
 
 			<TdsDropdown
-				name="error-dropdown"
+				name="disabled-dropdown"
 				label="Label text"
 				label-position="outside"
 				placeholder="Placeholder"


### PR DESCRIPTION
This PR currently contains a bump of the tegel-react version to the dropdown beta release, so that team mates can review our work with the variables.
It also contains more types of dropdowns in the dropdown page, to showcase functionalities.